### PR TITLE
Select database by project. Use inflxudb python lib

### DIFF
--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -656,14 +656,12 @@ class influxdb09(influxdb):
             else:
                 path = m.SERVICEDESC
 
-            # Ensure a int/float gets passed
+            # Ensure a float gets passed
+            # A measurement can not have integer and float values
             try:
-                value = int(m.VALUE)
+                value = float(m.VALUE)
             except ValueError:
-                try:
-                    value = float(m.VALUE)
-                except ValueError:
-                    value = 0
+                value = 0
 
             # Add project as tag
             try:

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -677,7 +677,7 @@ class influxdb09(influxdb):
 
         series_chunks = self.chunks(perfdata, self.influxdb_max_metrics)
         for chunk in series_chunks:
-            series = {"database": self.influxdb_db, "points": chunk}
+            series = {"database": project, "points": chunk}
             for s in self.influxdb_servers:
                 if not self._send(s, series):
                     ret = 0

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -660,7 +660,13 @@ class influxdb09(influxdb):
                 except ValueError:
                     value = 0
 
-            tags = {"check": m.LABEL, "host": m.HOSTNAME}
+            # Add project as tag
+            try:
+                project = m.PROJECT
+            except AttributeError:
+                project = "NA"
+
+            tags = {"check": m.LABEL, "host": m.HOSTNAME, "project": project}
             tags.update(self.influxdb_extra_tags)
 
             perfdata.append({


### PR DESCRIPTION
Use the project field added to the perfdata files to select which database use to write data.

Use influxdb python lib because json protocol is deprecated.
